### PR TITLE
critical fix

### DIFF
--- a/ItrkService.module
+++ b/ItrkService.module
@@ -204,6 +204,15 @@ class ItrkService extends Process
         // read more values from current legal text (LT) transmission
         $LT_Language	= $LTI->get_LT_Language();	// ISO 639-1 (lowercase, e.g. 'de' for German / Deutsch)
         $LT_Country		= $LTI->get_LT_Country();	// ISO 3166-1-alpha-2 (uppercase, e.g. 'DE' for Germany/Deutschland)
+        // legal text (LT) transmission service uses dummy country/Language "XX"
+        // to test login/passwort credentials are correct (exit here as those dummy texts should never be imported)
+        if (strtolower($LT_Language) == 'xx') {
+            $LTI->send_ERROR('Ungültige Sprache', '9');
+        }
+        if (strtolower($LT_Country) == 'xx') {
+            $LTI->send_ERROR('Ungültiges Land', '17');
+        }
+
         $LT_Title		= $LTI->get_LT_Title();		// can be used e.g. as a title for a CMS page
         $LT_Text		= $LTI->get_LT_Text();		// the legal text in text form
         $LT_HTML		= $LTI->get_LT_HTML();		// the legal text in HTML form

--- a/LegalTextInterface.php
+++ b/LegalTextInterface.php
@@ -342,8 +342,8 @@ class LegalTextInterface{
 	public function send_SUCCESS(){
 		$this->returnSuccess();
 	}
-	public function send_ERROR($param_errormessage = NULL){
-		$this->returnError('99', $param_errormessage);
+	public function send_ERROR($param_errormessage = NULL, $error_code = '99'){
+		$this->returnError($error_code, $param_errormessage);
 	}
 	
 	public function send_ERROR_shop_configuration_incomplete($param_errormessage = NULL){


### PR DESCRIPTION
Neue Schnittstellen (seit Januar 2022) verwenden einen Login/Passwort-Testmechanismus, um die Zugangsdaten zu testen.

Dabei wird ein Dummy-Dokument gesendet, dass keine Inhalte besitzt; Texte werden dabei mit dem Land und Sprache "xx" gekennzeichnet.

Alte Schnittstellen akzeptieren aufgrund fehlender Länder/Sprache Implementation die Dokumente jedoch und überschreiben dadurch bestehende/gültige Rechtstexte.

Das Update ist daher kritisch.

Fragen gerne an:
webdev@it-recht-kanzlei.de